### PR TITLE
Sending offer from the endpoint which needs negotiation.

### DIFF
--- a/src/sdk/base/src/main/java/owt/base/PeerConnectionChannel.java
+++ b/src/sdk/base/src/main/java/owt/base/PeerConnectionChannel.java
@@ -87,6 +87,7 @@ public abstract class PeerConnectionChannel
                 new KeyValuePair("OfferToReceiveVideo", String.valueOf(receiveVideo)));
         peerConnection = PCFactoryProxy.instance().createPeerConnection(configuration, this);
         RCHECK(peerConnection);
+        signalingState = peerConnection.signalingState();
     }
 
     //Utility method for getting the mediastream as it is package privileged.

--- a/src/sdk/p2p/src/main/java/owt/p2p/P2PClient.java
+++ b/src/sdk/p2p/src/main/java/owt/p2p/P2PClient.java
@@ -19,7 +19,6 @@ import static owt.p2p.P2PClient.ServerConnectionStatus.DISCONNECTED;
 import static owt.p2p.P2PClient.SignalingMessageType.CHAT_CLOSED;
 import static owt.p2p.P2PClient.SignalingMessageType.CHAT_DATA_ACK;
 import static owt.p2p.P2PClient.SignalingMessageType.CHAT_UA;
-import static owt.p2p.P2PClient.SignalingMessageType.NEGOTIATION_REQUEST;
 import static owt.p2p.P2PClient.SignalingMessageType.SIGNALING_MESSAGE;
 import static owt.p2p.P2PClient.SignalingMessageType.STREAM_INFO;
 import static owt.p2p.P2PClient.SignalingMessageType.TRACK_ADD_ACK;
@@ -706,7 +705,6 @@ public final class P2PClient implements PeerConnectionChannel.PeerConnectionChan
 
     @Override
     public void onRenegotiationRequest(String peerId) {
-        sendSignalingMessage(peerId, NEGOTIATION_REQUEST, null, null);
     }
 
     //SignalingChannelObserver
@@ -733,13 +731,6 @@ public final class P2PClient implements PeerConnectionChannel.PeerConnectionChan
                     synchronized (pcChannelsLock) {
                         if (pcChannels.containsKey(peerId)) {
                             getPeerConnection(peerId).processTrackAck(msgObj.getJSONArray("data"));
-                        }
-                    }
-                    break;
-                case NEGOTIATION_REQUEST:
-                    synchronized (pcChannelsLock) {
-                        if (pcChannels.containsKey(peerId)) {
-                            getPeerConnection(peerId).processNegotiationRequest();
                         }
                     }
                     break;
@@ -843,7 +834,6 @@ public final class P2PClient implements PeerConnectionChannel.PeerConnectionChan
     }
 
     enum SignalingMessageType {
-        NEGOTIATION_REQUEST("chat-negotiation-needed"),
         SIGNALING_MESSAGE("chat-signal"),
         TRACK_ADD_ACK("chat-tracks-added"),
         TRACK_INFO("chat-track-sources"),
@@ -861,8 +851,6 @@ public final class P2PClient implements PeerConnectionChannel.PeerConnectionChan
 
         static SignalingMessageType get(String type) {
             switch (type) {
-                case "chat-negotiation-needed":
-                    return NEGOTIATION_REQUEST;
                 case "chat-signal":
                     return SIGNALING_MESSAGE;
                 case "chat-tracks-added":

--- a/src/sdk/p2p/src/main/java/owt/p2p/P2PPeerConnectionChannel.java
+++ b/src/sdk/p2p/src/main/java/owt/p2p/P2PPeerConnectionChannel.java
@@ -62,9 +62,6 @@ final class P2PPeerConnectionChannel extends PeerConnectionChannel {
     private boolean continualIceGathering = true;
     private boolean everPublished = false;
 
-    // default isCaller true
-    private boolean isCaller = true;
-
     P2PPeerConnectionChannel(String peerId, P2PClientConfiguration configuration,
             PeerConnectionChannelObserver observer) {
         super(peerId, configuration.rtcConfiguration, true, true, observer);
@@ -213,14 +210,10 @@ final class P2PPeerConnectionChannel extends PeerConnectionChannel {
 
     void processNegotiationRequest() {
         synchronized (negLock) {
-            if (!negotiating) {
+            if (!negotiating && getSignalingState() == STABLE) {
                 negotiating = true;
                 renegotiationNeeded = false;
-                if (isCaller) {
-                    createOffer();
-                } else {
-                    observer.onRenegotiationRequest(key);
-                }
+                createOffer();
             } else {
                 renegotiationNeeded = true;
             }
@@ -362,7 +355,6 @@ final class P2PPeerConnectionChannel extends PeerConnectionChannel {
             Log.d(LOG_TAG, "onSetSuccess ");
             if (signalingState == PeerConnection.SignalingState.HAVE_REMOTE_OFFER
                     || peerConnection.getLocalDescription() == null) {
-                isCaller = false;
                 createAnswer();
             } else {
                 drainRemoteCandidates();


### PR DESCRIPTION
The offer side and answer side used to be fixed during a session. It's a problem as we changed to unified plan because there might be more than one M section in SDP, but the answer side cannot add more m sections when it is needed.

See also: https://github.com/open-webrtc-toolkit/owt-client-javascript/pull/116