### PR TITLE
Do not include libwebrtc.jar in base.aar.

### DIFF
--- a/src/sample/utils/build.gradle
+++ b/src/sample/utils/build.gradle
@@ -25,4 +25,5 @@ android {
 
 dependencies {
     api project(':src:sdk:base')
+    api files('../../../dependencies/libwebrtc/libwebrtc.jar')
 }

--- a/src/sdk/base/build.gradle
+++ b/src/sdk/base/build.gradle
@@ -24,9 +24,9 @@ android {
 }
 
 dependencies {
+    compileOnly files('libs/libwebrtc.jar')
     androidTestImplementation 'com.android.support:support-annotations:28.0.0'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation files('libs/libwebrtc.jar')
-    api files('libs/libwebrtc.jar')
 }

--- a/src/sdk/conference/build.gradle
+++ b/src/sdk/conference/build.gradle
@@ -24,6 +24,7 @@ android {
 }
 
 dependencies {
+    compileOnly files('../../../dependencies/libwebrtc/libwebrtc.jar')
     compileOnly('io.socket:socket.io-client:1.0.0') {
         // excluding org.json which is provided by Android
         exclude group: 'org.json', module: 'json'

--- a/src/sdk/p2p/build.gradle
+++ b/src/sdk/p2p/build.gradle
@@ -24,6 +24,7 @@ android {
 }
 
 dependencies {
+    compileOnly files('../../../dependencies/libwebrtc/libwebrtc.jar')
     compileOnly project(':src:sdk:base')
 
     androidTestImplementation 'com.android.support:support-annotations:28.0.0'


### PR DESCRIPTION
It allows developer to replace libwertc.jar with the upstream one or custom one.