### PR TITLE
Getting conference info in join's success callback sometimes returns null.

### DIFF
--- a/src/sdk/conference/src/main/java/owt/conference/ConferenceClient.java
+++ b/src/sdk/conference/src/main/java/owt/conference/ConferenceClient.java
@@ -590,10 +590,10 @@ public final class ConferenceClient implements SignalingChannel.SignalingChannel
             try {
                 if (joinCallback != null) {
                     conferenceInfo = new ConferenceInfo(info);
-                    joinCallback.onSuccess(conferenceInfo);
                     synchronized (infoLock) {
                         ConferenceClient.this.conferenceInfo = conferenceInfo;
                     }
+                    joinCallback.onSuccess(conferenceInfo);
                 }
             } catch (JSONException e) {
                 triggerCallback(joinCallback, new OwtError(e.getMessage()));


### PR DESCRIPTION
conferenceInfo will be null if application get infoLock before ConferenceClient.