### PR TITLE
Added ConferencePeerChannel null pointer checks, ConferencePeerConnec…

### DIFF
--- a/src/sdk/conference/src/main/java/owt/conference/ConferenceClient.java
+++ b/src/sdk/conference/src/main/java/owt/conference/ConferenceClient.java
@@ -726,7 +726,7 @@ public final class ConferenceClient implements SignalingChannel.SignalingChannel
                                 boolean active = updateInfo.getString("value").equals("active");
                                 if (pcChannel.publication != null) {
                                     pcChannel.publication.onStatusUpdated(trackKind, active);
-                                } else {
+                                } else if (pcChannel.subscription != null){
                                     pcChannel.subscription.onStatusUpdated(trackKind, active);
                                 }
                             }
@@ -891,7 +891,7 @@ public final class ConferenceClient implements SignalingChannel.SignalingChannel
             if (pcChannel.key.equals(id)) {
                 if (pcChannel.publication != null) {
                     pcChannel.publication.onError(error);
-                } else {
+                } else if (pcChannel.subscription != null){
                     pcChannel.subscription.onError(error);
                 }
             }


### PR DESCRIPTION
Added ConferencePeerChannel null pointer checks, ConferencePeerConnectionChannel instances are created by ConferencePeerChannel.getPeerConnection() but do not necessarily contain a publication or subscription

This fix will prevent many crashes in our app