### PR TITLE
upgrade dependency lib to fix CVE-2018-20200

### DIFF
--- a/src/sample/conference/build.gradle
+++ b/src/sample/conference/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support:support-v4:26.1.0'
-    implementation('io.socket:socket.io-client:1.0.0') {
+    implementation('io.socket:socket.io-client:1.0.1') {
         // excluding org.json which is provided by Android
         exclude group: 'org.json', module: 'json'
     }

--- a/src/sample/p2p/build.gradle
+++ b/src/sample/p2p/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
     implementation 'com.android.support:support-vector-drawable:26.0.0-beta1'
     implementation 'com.android.support:support-v4:26.1.0'
-    implementation('io.socket:socket.io-client:1.0.0') {
+    implementation('io.socket:socket.io-client:1.0.1') {
         // excluding org.json which is provided by Android
         exclude group: 'org.json', module: 'json'
     }

--- a/src/sdk/conference/build.gradle
+++ b/src/sdk/conference/build.gradle
@@ -25,7 +25,7 @@ android {
 
 dependencies {
     compileOnly files('../../../dependencies/libwebrtc/libwebrtc.jar')
-    compileOnly('io.socket:socket.io-client:1.0.0') {
+    compileOnly('io.socket:socket.io-client:1.0.1') {
         // excluding org.json which is provided by Android
         exclude group: 'org.json', module: 'json'
     }
@@ -34,7 +34,7 @@ dependencies {
     androidTestImplementation 'com.android.support:support-annotations:28.0.0'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
-    androidTestImplementation('io.socket:socket.io-client:1.0.0') {
+    androidTestImplementation('io.socket:socket.io-client:1.0.1') {
         // excluding org.json which is provided by Android
         exclude group: 'org.json', module: 'json'
     }

--- a/test/base/build.gradle
+++ b/test/base/build.gradle
@@ -35,7 +35,7 @@ repositories {
 }
 
 dependencies {
-    implementation('io.socket:socket.io-client:1.0.0') {
+    implementation('io.socket:socket.io-client:1.0.1') {
         // excluding org.json which is provided by Android
         exclude group: 'org.json', module: 'json'
     }

--- a/test/conference/util/build.gradle
+++ b/test/conference/util/build.gradle
@@ -27,7 +27,7 @@ repositories {
     }
 }
 dependencies {
-    implementation('io.socket:socket.io-client:1.0.0') {
+    implementation('io.socket:socket.io-client:1.0.1') {
         // excluding org.json which is provided by Android
         exclude group: 'org.json', module: 'json'
     }

--- a/test/p2p/util/build.gradle
+++ b/test/p2p/util/build.gradle
@@ -26,7 +26,7 @@ repositories {
     }
 }
 dependencies {
-    implementation('io.socket:socket.io-client:1.0.0') {
+    implementation('io.socket:socket.io-client:1.0.1') {
         // excluding org.json which is provided by Android
         exclude group: 'org.json', module: 'json'
     }


### PR DESCRIPTION
io.socket:socket.io-client:1.0.0 depends okhttp 3.8.1
okhttp 3.8.1 has security vulnerablity CVE-2018-20200

upgrade io.socket:socket.io-client:1.0.1 who depends on okhttp
3.12.12, fixed the vulnerability

Signed-off-by: Tiger Meng <xiao.xi.meng@intel.com>