### PR TITLE
Peer connection stream checks in ConferenceClient.onStreamUpdated() to prevent possible null pointer

### DIFF
--- a/src/sdk/base/src/main/java/owt/base/Stream.java
+++ b/src/sdk/base/src/main/java/owt/base/Stream.java
@@ -153,6 +153,14 @@ public abstract class Stream {
     }
 
     /**
+     * Check if the Stream is disposed
+     * @return true if Stream is disposed; otherwise, false.
+     */
+    public boolean disposed() {
+        return mediaStream == null;
+    }
+
+    /**
      * Information of the source of a Stream.
      */
     public static class StreamSourceInfo {

--- a/src/sdk/conference/src/main/java/owt/conference/ConferenceClient.java
+++ b/src/sdk/conference/src/main/java/owt/conference/ConferenceClient.java
@@ -735,7 +735,7 @@ public final class ConferenceClient implements SignalingChannel.SignalingChannel
                         for (ConferencePeerConnectionChannel pcChannel : pcChannels.values()) {
                             // For subscription id will be the RemoteStream id, for publication
                             // the id will be publication id which is pc.key.
-                            if(pcChannel.stream.disposed()) {
+                            if(pcChannel.stream == null || pcChannel.stream.disposed()) {
                                 continue;
                             }
                             if (pcChannel.stream.id().equals(id) || pcChannel.key.equals(id)) {

--- a/src/sdk/conference/src/main/java/owt/conference/ConferenceClient.java
+++ b/src/sdk/conference/src/main/java/owt/conference/ConferenceClient.java
@@ -735,6 +735,9 @@ public final class ConferenceClient implements SignalingChannel.SignalingChannel
                         for (ConferencePeerConnectionChannel pcChannel : pcChannels.values()) {
                             // For subscription id will be the RemoteStream id, for publication
                             // the id will be publication id which is pc.key.
+                            if(pcChannel.stream.disposed()) {
+                                continue;
+                            }
                             if (pcChannel.stream.id().equals(id) || pcChannel.key.equals(id)) {
                                 TrackKind trackKind = field.equals("audio.status")
                                         ? TrackKind.AUDIO : TrackKind.VIDEO;

--- a/src/sdk/conference/src/main/java/owt/conference/ConferenceClient.java
+++ b/src/sdk/conference/src/main/java/owt/conference/ConferenceClient.java
@@ -247,6 +247,10 @@ public final class ConferenceClient implements SignalingChannel.SignalingChannel
             sendSignalingMessage("publish", publishMsg, args -> {
                 if (extractMsg(0, args).equals("ok")) {
                     try {
+                        if(localStream.disposed()) {
+                            triggerCallback(callback, new OwtError("Local stream disposed on publish."));
+                            return;
+                        }
                         JSONObject result = (JSONObject) args[1];
                         // Do not receive video and audio for publication cpcc.
                         ConferencePeerConnectionChannel pcChannel =
@@ -326,6 +330,7 @@ public final class ConferenceClient implements SignalingChannel.SignalingChannel
             return;
         }
 
+        final String remoteStreamId = remoteStream.id();
         final boolean subVideo = options == null || options.videoOption != null;
         final boolean subAudio = options == null || options.audioOption != null;
 
@@ -333,7 +338,7 @@ public final class ConferenceClient implements SignalingChannel.SignalingChannel
             JSONObject media = new JSONObject();
             if (subVideo) {
                 JSONObject video = new JSONObject();
-                video.put("from", remoteStream.id());
+                video.put("from", remoteStreamId);
                 if (options != null) {
                     video.put("parameters", options.videoOption.generateOptionsMsg());
                     if (options.videoOption.rid != null) {
@@ -346,7 +351,7 @@ public final class ConferenceClient implements SignalingChannel.SignalingChannel
             }
             if (subAudio) {
                 JSONObject audio = new JSONObject();
-                audio.put("from", remoteStream.id());
+                audio.put("from", remoteStreamId);
                 media.put("audio", audio);
             } else {
                 media.put("audio", false);
@@ -358,7 +363,15 @@ public final class ConferenceClient implements SignalingChannel.SignalingChannel
             sendSignalingMessage("subscribe", subscribeMsg, args -> {
                 if (extractMsg(0, args).equals("ok")) {
                     for (ConferencePeerConnectionChannel pcChannel : pcChannels.values()) {
-                        if (pcChannel.stream.id().equals(remoteStream.id())) {
+                        if(pcChannel.stream == null) {
+                            Log.w(LOG_TAG, "Peer connection channel stream is null.");
+                            continue;
+                        }
+                        if(pcChannel.stream.disposed()) {
+                            Log.w(LOG_TAG, "Peer connection channel stream is disposed.");
+                            continue;
+                        }
+                        if (pcChannel.stream.id().equals(remoteStreamId)) {
                             triggerCallback(callback,
                                     new OwtError("Remote stream has been subscribed."));
                             return;
@@ -707,10 +720,12 @@ public final class ConferenceClient implements SignalingChannel.SignalingChannel
                 switch (field) {
                     case "video.layout":
                         synchronized (infoLock) {
-                            for (RemoteStream remoteStream : conferenceInfo.remoteStreams) {
-                                if (remoteStream.id().equals(id)) {
-                                    ((RemoteMixedStream) remoteStream).updateRegions(
-                                            updateInfo.getJSONArray("value"));
+                            if(conferenceInfo != null) {
+                                for (RemoteStream remoteStream : conferenceInfo.remoteStreams) {
+                                    if (remoteStream.id().equals(id)) {
+                                        ((RemoteMixedStream) remoteStream).updateRegions(
+                                                updateInfo.getJSONArray("value"));
+                                    }
                                 }
                             }
                         }
@@ -734,19 +749,25 @@ public final class ConferenceClient implements SignalingChannel.SignalingChannel
                         break;
                     case "activeInput":
                         synchronized (infoLock) {
-                            for (RemoteStream remoteStream : conferenceInfo.remoteStreams) {
-                                if (remoteStream.id().equals(id)) {
-                                    ((RemoteMixedStream) remoteStream).updateActiveInput(
-                                            updateInfo.getString("value"));
+                            if(conferenceInfo != null) {
+                                for (RemoteStream remoteStream : conferenceInfo.remoteStreams) {
+                                    if (remoteStream.id().equals(id)) {
+                                        ((RemoteMixedStream) remoteStream).updateActiveInput(
+                                                updateInfo.getString("value"));
+                                    }
                                 }
                             }
                         }
                         break;
                     case ".":
-                        for (RemoteStream remoteStream : conferenceInfo.remoteStreams) {
-                            if (remoteStream.id().equals(id)) {
-                                JSONObject streamInfo = updateInfo.getJSONObject("value");
-                                remoteStream.updateStreamInfo(streamInfo, true);
+                        synchronized (infoLock) {
+                            if (conferenceInfo != null) {
+                                for (RemoteStream remoteStream : conferenceInfo.remoteStreams) {
+                                    if (remoteStream.id().equals(id)) {
+                                        JSONObject streamInfo = updateInfo.getJSONObject("value");
+                                        remoteStream.updateStreamInfo(streamInfo, true);
+                                    }
+                                }
                             }
                         }
                         break;


### PR DESCRIPTION
Added peer connection stream null and disposed checks to ConferenceClient.onStreamUpdated() to prevent possible null pointer crash.

Fix is closely related to previously accepted pull request https://github.com/open-webrtc-toolkit/owt-client-android/pull/267