### PR TITLE
Fix traversal crash of queuedRemoteCandidates

### DIFF
--- a/src/sdk/base/src/main/java/owt/base/PeerConnectionChannel.java
+++ b/src/sdk/base/src/main/java/owt/base/PeerConnectionChannel.java
@@ -173,18 +173,20 @@ public abstract class PeerConnectionChannel
     protected void drainRemoteCandidates() {
         DCHECK(pcExecutor);
         DCHECK(queuedRemoteCandidates);
-        synchronized (remoteIceLock) {
-            for (final IceCandidate candidate : queuedRemoteCandidates) {
-                pcExecutor.execute(() -> {
+        pcExecutor.execute(() -> {
+            synchronized (remoteIceLock) {
+                Iterator<IceCandidate> iterator = queuedRemoteCandidates.iterator();
+                while (iterator.hasNext()) {
                     if (disposed()) {
                         return;
                     }
+                    IceCandidate candidate = iterator.next();
                     Log.d(LOG_TAG, "add ice candidate");
                     peerConnection.addIceCandidate(candidate);
-                    queuedRemoteCandidates.remove(candidate);
-                });
+                    iterator.remove();
+                }
             }
-        }
+        });
     }
 
     private void setRemoteDescription(final SessionDescription remoteDescription) {


### PR DESCRIPTION
It is also dangerous to use a for loop to traverse the list outside the pc thread.
Especially when the code running efficiency is slowed down in debug mode, it is more likely to cause a crash when the remove is executed before the loop is completed.