### PR TITLE
Stop a transceiver if its direction is inactive.

### DIFF
--- a/src/sdk/base/src/main/java/owt/base/PeerConnectionChannel.java
+++ b/src/sdk/base/src/main/java/owt/base/PeerConnectionChannel.java
@@ -225,6 +225,11 @@ public abstract class PeerConnectionChannel
             if (videoRtpSenders.get(mediaStreamId) != null) {
                 peerConnection.removeTrack(videoRtpSenders.get(mediaStreamId));
             }
+            for (RtpTransceiver transceiver : peerConnection.getTransceivers()) {
+                if (transceiver.getDirection() == RtpTransceiver.RtpTransceiverDirection.INACTIVE && !transceiver.isStopped()) {
+                    transceiver.stop();
+                }
+            }
         });
     }
 


### PR DESCRIPTION
It avoids too much resources being used by inactive transceivers. For example,
if the app frequently publish a stream and unpublish it, there will be a lot of
inactive transceivers.